### PR TITLE
Fix blank innerHTML when text attribute is blank

### DIFF
--- a/marked-element.html
+++ b/marked-element.html
@@ -37,6 +37,8 @@ Element wrapper for the `marked` (http://marked.org/) library.
     textChanged: function (oldVal, newVal) {
       if (newVal) {
         this.innerHTML = marked(this.text);
+      } else {
+        this.innerHTML = "";
       }
     },
 


### PR DESCRIPTION
When text attribute is set to blank "", set innerHTML to blank "".

Fixes issue #5 