### PR TITLE
fixed import by pointing to marked-js.html

### DIFF
--- a/marked-import.html
+++ b/marked-import.html
@@ -7,4 +7,4 @@
     Code distributed by Google as part of the polymer project is also
     subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<script src='../marked/lib/marked.js'></script>
+<link rel="import" href="../marked-js/marked-js.html">


### PR DESCRIPTION
It was pointing to a file in the original "marked" repo (has to be manually pulled), but there is a "marked-js" repository under Polymer that provides a proper import component. It's more likely to be present anyway.