### PR TITLE
0.8 Preview (with `<script>`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,16 @@
 {
   "name": "marked-element",
   "private": true,
+  "authors": [
+    "The Polymer Project Authors"
+  ],
   "dependencies": {
     "polymer": "Polymer/polymer#master",
     "marked": "~0.3.3"
+  },
+  "main": "marked-element.html",
+  "repo": {
+    "type": "git",
+    "url": "git://github.com/Polymer/marked-element.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "marked-element",
   "private": true,
   "dependencies": {
-    "marked": "*",
-    "polymer": "Polymer/polymer#master"
+    "polymer": "Polymer/polymer#master",
+    "marked": "~0.3.3"
   }
 }

--- a/demo.html
+++ b/demo.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -8,20 +8,20 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
-  <head>
+<head>
+  <meta charset="UTF-8">
+  <title>marked-element demo</title>
 
-    <title>marked-element demo</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <link rel="import" href="marked-element.html">
-  </head>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="marked-element.html">
+</head>
 
-  <body unresolved>
+<body>
 
+  <section>
     <h3>Inline Text</h3>
-    <hr>
-
     <marked-element>
+      <script type="text/markdown">
 ## Markdown Renderer
 
 * implemented in `JavaScript`
@@ -29,24 +29,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 Example:
 
-    <div>
-      <core-overlay>
-        <h2>Dialog</h2>
-        <input placeholder="say something..." autofocus>
-        <div>I agree with this wholeheartedly.</div>
-        <button core-overlay-toggle>OK</button>
-      </core-overlay>
-    </div>
+```html
+<div>
+  <core-overlay>
+    <h2>Dialog</h2>
+    <input placeholder="say something..." autofocus>
+    <div>I agree with this wholeheartedly.</div>
+    <button core-overlay-toggle>OK</button>
+  </core-overlay>
+</div>
+```
 
 _Nifty_ features.
+      </script>
     </marked-element>
+  </section>
 
-    <br>
-
+  <section>
     <h3>Text via Attribute</h3>
-    <hr>
-
     <marked-element text="    <div>div</div>"></marked-element>
+  </section>
 
-  </body>
+</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="UTF-8">
   <title>marked-element demo</title>
 
-  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="marked-element.html">
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../marked-element.html">
 </head>
 
 <body>

--- a/marked-element.html
+++ b/marked-element.html
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -15,31 +15,48 @@ Element wrapper for the `marked` (http://marked.org/) library.
 
 @class marked-element
 @blurb Element wrapper for the marked library.
-@status alpha
-@snap snap.png
 -->
-<polymer-element name="marked-element" attributes="text">
+<dom-module id="marked-element">
+
+  <template>
+    <div id="content"></div>
+  </template>
+
+</dom-module>
+
 <script>
 
-  Polymer('marked-element', {
+  Polymer({
 
-    text: '',
+    is: 'marked-element',
+
+    properties: {
+
+      text: {
+        observer: 'textChanged',
+        type: String,
+        value: null
+      }
+
+    },
 
     attached: function() {
       marked.setOptions({
         highlight: this.highlight.bind(this)
       });
+
       if (!this.text) {
-        this.text = this.innerHTML;
+        // Use the Markdown from the first `<script>` descendant whose MIME type starts with
+        // "text/markdown". Script elements beyond the first are ignored
+        var markdownEl = Polymer.dom(this).querySelector('[type^="text/markdown"]');
+        if (markdownEl != null) {
+          this.text = markdownEl.innerHTML;
+        }
       }
     },
 
-    textChanged: function (oldVal, newVal) {
-      if (newVal) {
-        this.innerHTML = marked(this.text);
-      } else {
-        this.innerHTML = "";
-      }
+    textChanged: function (newVal, oldVal) {
+      this.$.content.innerHTML = newVal ? marked(this.text) : '';
     },
 
     highlight: function(code, lang) {
@@ -50,5 +67,3 @@ Element wrapper for the `marked` (http://marked.org/) library.
   });
 
 </script>
-</polymer-element>
-


### PR DESCRIPTION
The new Marked element uses the content from its first
`<script type="text/markdown">` descendant so that the text is not
parsed as HTML by the browser before being interpreted as Markdown.

Usage:

```
<marked-element>
  <script type="text/markdown">
    # Stuff interpreted as Markdown
  </script>
</marked-element>
```
