### PR TITLE
0.8 Port + Full Markdown support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,16 @@
 {
   "name": "marked-element",
   "private": true,
+  "authors": [
+    "The Polymer Project Authors"
+  ],
   "dependencies": {
     "polymer": "Polymer/polymer#master",
     "marked": "~0.3.3"
+  },
+  "main": "marked-element.html",
+  "repo": {
+    "type": "git",
+    "url": "git://github.com/Polymer/marked-element.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "marked-element",
   "private": true,
   "dependencies": {
-    "marked": "*",
-    "polymer": "Polymer/polymer#master"
+    "polymer": "Polymer/polymer#master",
+    "marked": "~0.3.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,12 +2,13 @@
   "name": "marked-element",
   "private": true,
   "authors": [
-    "The Polymer Project Authors"
+    "The Polymer Project Authors (https://polymer.github.io/AUTHORS.txt)"
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#0.8-preview",
     "marked": "~0.3.3"
   },
+  "license": "https://polymer.github.io/LICENSE.txt",
   "main": "marked-element.html",
   "repo": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "The Polymer Project Authors"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#master",
+    "polymer": "Polymer/polymer#0.8-preview",
     "marked": "~0.3.3"
   },
   "main": "marked-element.html",

--- a/demo.html
+++ b/demo.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -8,20 +8,20 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
-  <head>
+<head>
+  <meta charset="UTF-8">
+  <title>marked-element demo</title>
 
-    <title>marked-element demo</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <link rel="import" href="marked-element.html">
-  </head>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="marked-element.html">
+</head>
 
-  <body unresolved>
+<body>
 
+  <section>
     <h3>Inline Text</h3>
-    <hr>
-
     <marked-element>
+      <script type="text/markdown">
 ## Markdown Renderer
 
 * implemented in `JavaScript`
@@ -29,24 +29,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 Example:
 
-    <div>
-      <core-overlay>
-        <h2>Dialog</h2>
-        <input placeholder="say something..." autofocus>
-        <div>I agree with this wholeheartedly.</div>
-        <button core-overlay-toggle>OK</button>
-      </core-overlay>
-    </div>
+```html
+<div>
+  <core-overlay>
+    <h2>Dialog</h2>
+    <input placeholder="say something..." autofocus>
+    <div>I agree with this wholeheartedly.</div>
+    <button core-overlay-toggle>OK</button>
+  </core-overlay>
+</div>
+```
 
 _Nifty_ features.
+      </script>
     </marked-element>
+  </section>
 
-    <br>
-
+  <section>
     <h3>Text via Attribute</h3>
-    <hr>
-
     <marked-element text="    <div>div</div>"></marked-element>
+  </section>
 
-  </body>
+</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="UTF-8">
   <title>marked-element demo</title>
 
-  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="marked-element.html">
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../marked-element.html">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
 The complete set of authors may be found at http://polymer.github.io/AUTHORS
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS

--- a/marked-element.html
+++ b/marked-element.html
@@ -26,6 +26,8 @@ Element wrapper for the `marked` (http://marked.org/) library.
 
 <script>
 
+  'use strict';
+
   Polymer({
 
     is: 'marked-element',

--- a/marked-element.html
+++ b/marked-element.html
@@ -47,10 +47,10 @@ Element wrapper for the `marked` (http://marked.org/) library.
 
       if (!this.text) {
         // Use the Markdown from the first `<script>` descendant whose MIME type starts with
-        // "text/markdown". Script elements beyond the first are ignored
+        // "text/markdown". Script elements beyond the first are ignored.
         var markdownEl = Polymer.dom(this).querySelector('[type^="text/markdown"]');
         if (markdownEl != null) {
-          this.text = markdownEl.innerHTML;
+          this.text = markdownEl.textContent;
         }
       }
     },

--- a/marked-element.html
+++ b/marked-element.html
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -15,31 +15,48 @@ Element wrapper for the `marked` (http://marked.org/) library.
 
 @class marked-element
 @blurb Element wrapper for the marked library.
-@status alpha
-@snap snap.png
 -->
-<polymer-element name="marked-element" attributes="text">
+<dom-module id="marked-element">
+
+  <template>
+    <div id="content"></div>
+  </template>
+
+</dom-module>
+
 <script>
 
-  Polymer('marked-element', {
+  Polymer({
 
-    text: '',
+    is: 'marked-element',
+
+    properties: {
+
+      text: {
+        observer: 'textChanged',
+        type: String,
+        value: null
+      }
+
+    },
 
     attached: function() {
       marked.setOptions({
         highlight: this.highlight.bind(this)
       });
+
       if (!this.text) {
-        this.text = this.innerHTML;
+        // Use the Markdown from the first `<script>` descendant whose MIME type starts with
+        // "text/markdown". Script elements beyond the first are ignored
+        var markdownEl = Polymer.dom(this).querySelector('[type^="text/markdown"]');
+        if (markdownEl != null) {
+          this.text = markdownEl.innerHTML;
+        }
       }
     },
 
-    textChanged: function (oldVal, newVal) {
-      if (newVal) {
-        this.innerHTML = marked(this.text);
-      } else {
-        this.innerHTML = "";
-      }
+    textChanged: function (newVal, oldVal) {
+      this.$.content.innerHTML = newVal ? marked(this.text) : '';
     },
 
     highlight: function(code, lang) {
@@ -50,5 +67,3 @@ Element wrapper for the `marked` (http://marked.org/) library.
   });
 
 </script>
-</polymer-element>
-

--- a/marked-element.html
+++ b/marked-element.html
@@ -40,7 +40,7 @@ Element wrapper for the `marked` (http://marked.org/) library.
 
     },
 
-    attached: function() {
+    ready: function() {
       marked.setOptions({
         highlight: this.highlight.bind(this)
       });

--- a/marked-element.html
+++ b/marked-element.html
@@ -50,9 +50,9 @@ Element wrapper for the `marked` (http://marked.org/) library.
       if (!this.text) {
         // Use the Markdown from the first `<script>` descendant whose MIME type starts with
         // "text/markdown". Script elements beyond the first are ignored.
-        var markdownEl = Polymer.dom(this).querySelector('[type^="text/markdown"]');
-        if (markdownEl != null) {
-          this.text = markdownEl.textContent;
+        var markdownElement = Polymer.dom(this).querySelector('[type^="text/markdown"]');
+        if (markdownElement != null) {
+          this.text = markdownElement.textContent;
         }
       }
     },

--- a/marked-import.html
+++ b/marked-import.html
@@ -1,10 +1,10 @@
 <!--
-    @license
-    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-    Code distributed by Google as part of the polymer project is also
-    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script src='../marked/lib/marked.js'></script>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'marked-element.html'
+    ]);
+  </script>
+</body>
+</html>

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -40,9 +40,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('<marked-element>', function() {
 
-      test('preserves camelCase code', function() {
-        var markedElement = fixture('CamelCaseHTML');
+      var markedElement
 
+      setup(function() {
+        markedElement = fixture('CamelCaseHTML');
+      });
+
+      test('preserves camelCase code', function() {
         // If Markdown content were put into a `<template>` or directly into the
         // DOM, it would be rendered as DOM and be converted from camelCase to
         // lowercase per HTML parsing rules. By using `<script>` descendants,

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>marked-element basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../marked-element.html">
+</head>
+<body>
+
+  <test-fixture id="CamelCaseHTML">
+    <template>
+      <marked-element>
+        <script type="text/markdown">
+```html
+<div camelCase></div>
+```
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
+  <script>
+    'use strict';
+
+    suite('<marked-element>', function() {
+
+      test('preserves camelCase code', function() {
+        var markedElement = fixture('CamelCaseHTML');
+
+        // If Markdown content were put into a `<template>` or directly into the
+        // DOM, it would be rendered as DOM and be converted from camelCase to
+        // lowercase per HTML parsing rules. By using `<script>` descendants,
+        // content is interpreted as plain text.
+        expect(markedElement.$.content.innerHTML).to.include('camelCase');
+      });
+
+    });
+
+  </script>
+
+</body>
+</html>

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -50,9 +50,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
-    // Replace '<' and '>' with their character entity equivalents.
+    // Replace reserved HTML characters with their character entity equivalents to match the
+    // transform done by Markdown.
+    //
+    // The Marked library itself is not used because it wraps code blocks in `<code><pre>`, which is
+    // superfluous for testing puproses.
     function escapeHTML(string) {
-      return string.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      var span = document.createElement('span');
+      span.textContent = string;
+      return span.innerHTML;
     }
 
     suite('<marked-element>', function() {

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -50,6 +50,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
+    // Replace '<' and '>' with their character entity equivalents.
+    function escapeHTML(string) {
+      return string.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
     suite('<marked-element>', function() {
 
       suite('respsects camelCased HTML', function() {
@@ -68,7 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // rendered as DOM and be converted from camelCase to lowercase per HTML parsing rules. By
           // using `<script>` descendants, content is interpreted as plain text.
           expect(proofElement.innerHTML).to.eql('<div camelcase=""></div>')
-          expect(markedElement.$.content.innerHTML).to.include('&lt;div camelCase&gt;');
+          expect(markedElement.$.content.innerHTML).to.include(escapeHTML('<div camelCase>'));
         });
       });
 
@@ -88,7 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // rendered as DOM and close unbalanced tags. Because they are in code blocks they should
           // remain as typed.
           expect(proofElement.innerHTML).to.eql('<p></p><div><p></p></div>');
-          expect(markedElement.$.content.innerHTML).to.include('&lt;p&gt;&lt;div&gt;&lt;/p&gt;&lt;/div&gt;');
+          expect(markedElement.$.content.innerHTML).to.include(escapeHTML('<p><div></p></div>'));
         });
       });
 

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -35,23 +35,61 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="BadHTML">
+    <template>
+      <marked-element>
+        <script type="text/markdown">
+```html
+<p><div></p></div>
+```
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
   <script>
     'use strict';
 
     suite('<marked-element>', function() {
 
-      var markedElement
+      suite('respsects camelCased HTML', function() {
+        var markedElement;
+        var proofElement;
 
-      setup(function() {
-        markedElement = fixture('CamelCaseHTML');
+        setup(function() {
+          markedElement = fixture('CamelCaseHTML');
+          proofElement = document.createElement('div');
+        });
+
+        test('in code blocks', function() {
+          proofElement.innerHTML = '<div camelCase></div>';
+
+          // If Markdown content were put into a `<template>` or directly into the DOM, it would be
+          // rendered as DOM and be converted from camelCase to lowercase per HTML parsing rules. By
+          // using `<script>` descendants, content is interpreted as plain text.
+          expect(proofElement.innerHTML).to.eql('<div camelcase=""></div>')
+          expect(markedElement.$.content.innerHTML).to.include('&lt;div camelCase&gt;');
+        });
       });
 
-      test('preserves camelCase code', function() {
-        // If Markdown content were put into a `<template>` or directly into the
-        // DOM, it would be rendered as DOM and be converted from camelCase to
-        // lowercase per HTML parsing rules. By using `<script>` descendants,
-        // content is interpreted as plain text.
-        expect(markedElement.$.content.innerHTML).to.include('camelCase');
+    suite('respsects bad HTML', function() {
+        var markedElement;
+        var proofElement;
+
+        setup(function() {
+          markedElement = fixture('BadHTML');
+          proofElement = document.createElement('div');
+        });
+
+        test('in code blocks', function() {
+          proofElement.innerHTML = '<p><div></p></div>';
+
+          // If Markdown content were put into a `<template>` or directly into the DOM, it would be
+          // rendered as DOM and close unbalanced tags. Because they are in code blocks they should
+          // remain as typed.
+          expect(proofElement.innerHTML).to.eql('<p></p><div><p></p></div>');
+          expect(markedElement.$.content.innerHTML).to.include('&lt;p&gt;&lt;div&gt;&lt;/p&gt;&lt;/div&gt;');
+        });
       });
 
     });

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // transform done by Markdown.
     //
     // The Marked library itself is not used because it wraps code blocks in `<code><pre>`, which is
-    // superfluous for testing puproses.
+    // superfluous for testing purposes.
     function escapeHTML(string) {
       var span = document.createElement('span');
       span.textContent = string;


### PR DESCRIPTION
### New Usage:

``` html
<marked-element>
  <script type="text/markdown">
## Correctly rendered Markdown (code blocks are not modified)

    <div fooBar></div>

    <!-- Some bad markup example, output properly -->
    <span><p></span></p>
  </script>
</marked-element>
```
### Why a `<script>`?

Previously the content of the `<markdown-element>` tag was allowed to be parsed as HTML and then converted back to text via `.innerHTML`. In this version this tag expects a `<script type="text/markdown">` descendant to contain the markup. Browsers do not parse the content, which ensures the text is converted as expected.

**Previously:**

``` html
<marked-element>
    <div fooBar></div>
</marked-element>
```

Rendered HTML incorrectly downcasing `fooBar` and adding a value of `""` because it was interpreted as HTML before being processed as Markdown:

``` html
<marked-element>
<code><pre>
&lt;div foobar=""&gt;&lt;/div&gt;
</pre></code>
</marked-element>
```

**Now:**

``` html
<marked-element>
  <script type="text/markdown">
    <div fooBar></div>
  </script>
</marked-element>
```

Output exactly matches input because the content is not passed through the browser's HTML parser before being used as text.

``` html
<marked-element>
<code><pre>
&lt;div fooBar&gt;&lt;/div&gt;
</pre></code>
</marked-element>
```
